### PR TITLE
Fix inverted LTE and GTE

### DIFF
--- a/src/main/kotlin/org/ojalgo/okalgo/optimization.kt
+++ b/src/main/kotlin/org/ojalgo/okalgo/optimization.kt
@@ -194,12 +194,12 @@ class ExpressionBuilder {
     }
 
     infix fun GTE(number: Int): ExpressionBuilder {
-        items += { upper(number) }
+        items += { lower(number) }
         return this
     }
 
     infix fun LTE(number: Int): ExpressionBuilder {
-        items += { lower(number) }
+        items += { upper(number) }
         return this
     }
 


### PR DESCRIPTION
Fix #4

Note it was only inverted for expression builder on the left of the sign.
It was correct when the left of the sign was a constant (`Number`) and the variable/expression was on the right.